### PR TITLE
Add localization to tooltips

### DIFF
--- a/resources/assets/js/components/posts/buttons/favorite.vue
+++ b/resources/assets/js/components/posts/buttons/favorite.vue
@@ -3,11 +3,11 @@
 
     <div class="btn-group">
 
-        <a v-if='post.favorited' title="Treure de favorits" class="btn btn-default sns-btn-post-options" @click="unfavorite($event)">
+        <a v-if='post.favorited' :title="[ trans('messages.remove_from_favorites') ]" class="btn btn-default sns-btn-post-options" @click="unfavorite($event)">
             <span class="glyphicon glyphicon glyphicon-bookmark"></span>
             <span v-if='post.num_favorites'> {{ post.num_favorites }} </span>
         </a>
-        <a v-else title="Afegir a favorits" class="btn btn-default sns-btn-post-options" @click="favorite($event)">
+        <a v-else :title="[ trans('messages.add_to_favorites') ]" class="btn btn-default sns-btn-post-options" @click="favorite($event)">
             <span class="glyphicon glyphicon glyphicon-bookmark sns-grey"></span>
             <span v-if='post.num_favorites'> {{ post.num_favorites }} </span>
         </a>

--- a/resources/assets/js/components/posts/buttons/like.vue
+++ b/resources/assets/js/components/posts/buttons/like.vue
@@ -1,12 +1,12 @@
  
 <template>
 	
-		 <a v-if='post.liked' title="Ja no m'agrada" class="btn btn-default sns-btn-post-options" @click="unlike($event)">
+		 <a v-if='post.liked' :title="[ trans('messages.dislike') ]" class="btn btn-default sns-btn-post-options" @click="unlike($event)">
 		    <span class="glyphicon glyphicon glyphicon-heart"></span>
 		    <span v-if='post.num_likes'>{{ post.num_likes }}</span>
 		 </a>
 		 
-		 <a v-else title="M'agrada" class="btn btn-default sns-btn-post-options" @click="like($event)">
+		 <a v-else :title="[ trans('messages.like') ]" class="btn btn-default sns-btn-post-options" @click="like($event)">
 		    <span class="glyphicon glyphicon glyphicon-heart sns-grey"></span>
 		    <span v-if='post.num_likes'>{{ post.num_likes }}</span>
 		 </a>

--- a/resources/assets/js/components/posts/buttons/share.vue
+++ b/resources/assets/js/components/posts/buttons/share.vue
@@ -3,7 +3,7 @@
     <div class="btn-group">
 
         <button type="button" class="btn btn-default dropdown-toggle sns-btn-post-options" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <span title="Comparteix" class="glyphicon glyphicon glyphicon-share-alt"></span> <span class="caret"></span>
+            <span :title="[ trans('messages.share') ]" class="glyphicon glyphicon glyphicon-share-alt"></span> <span class="caret"></span>
         </button>
         <ul class="dropdown-menu">
 

--- a/resources/lang/ca/messages.php
+++ b/resources/lang/ca/messages.php
@@ -69,7 +69,7 @@ return [
     'optimal'               => 'Òptim',                     /* container.vue, /sinasi/create.blade.php, /sinasi/edit.blade.php */
     'gallery'               => 'Galeria',                   /* container.vue, /sinasi/create.blade.php, /sinasi/edit.blade.php */
     'list'                  => 'Llista',                    /* container.vue, /sinasi/create.blade.php, /sinasi/edit.blade.php */
-    'share'                 => 'Compartir',                 /* container.vue, share.vue */
+    'share'                 => 'Comparteix',                /* container.vue, share.vue */
     'expand'                => 'Expandir',                  /* container.vue */
     'featured'              => 'Destacats',                 /* container.vue */
     'top_rated'             => 'Més votats',                /* container.vue */

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -69,7 +69,7 @@ return [
     'optimal'               => 'Òptim',                     /* container.vue, /sinasi/create.blade.php, /sinasi/edit.blade.php */
     'gallery'               => 'Galeria',                   /* container.vue, /sinasi/create.blade.php, /sinasi/edit.blade.php */
     'list'                  => 'Llista',                    /* container.vue, /sinasi/create.blade.php, /sinasi/edit.blade.php */
-    'share'                 => 'Compartir',                 /* container.vue */
+    'share'                 => 'Comparteix',                /* container.vue, share.vue */
     'expand'                => 'Expandir',                  /* container.vue */
     'featured'              => 'Destacats',                 /* container.vue */
     'top_rated'             => 'Més votats',                /* container.vue */
@@ -361,4 +361,6 @@ return [
     'st'                                => 'ST',                                    /* entity/create.blade.php, entity/edit.blade.php */
     'entity'                            => 'Centre',                                /* entity/index.blade.php */
     'role'                              => 'Rol',                                   /* user/edit.blade.php */
+
 ];
+


### PR DESCRIPTION
Afegir la localització per la traducció als tooltips.

Per provar-ho:

- Passar el ratolí per sobre els botons d'accions dels articles (a portada) i observar que el tooltip desplegat conté la traducció correcta.